### PR TITLE
Added sudo a couple places that needed it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,8 @@ sudo rosdep init
 rosdep update
 
 # Create a service
-cp ./run.sh /opt/openag_run.sh
-cp ./openag.service /lib/systemd/system/openag.service
+sudo cp ./run.sh /opt/openag_run.
+sudo cp ./openag.service /lib/systemd/system/openag.service
 
 # Create a catkin workspace
 mkdir -p ~/ros_catkin_ws


### PR DESCRIPTION
When I tried running the current version of the install script, it gave a "permission denied" error when trying to copy the `.run` and `.service` files into place. We should either add `sudo` to these 2 lines (which is what this PR does) or remove every instance of `sudo` from the script for consistency.