### PR TITLE
Revert "Revert "Install usb_cam""

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ cd ~/ros_catkin_ws
 # Install ros_comm and rosserial
 echo Generating rosinstall file...
 rm -f indigo.rosinstall src/.rosinstall
-rosinstall_generator ros_comm rosserial rosserial_arduino --rosdistro indigo --deps --wet-only --exclude roslisp --tar > indigo.rosinstall
+rosinstall_generator ros_comm rosserial rosserial_arduino usb_cam --rosdistro indigo --deps --wet-only --exclude roslisp --tar > indigo.rosinstall
 wstool init src indigo.rosinstall
 
 # Install dependencies for all installed packages


### PR DESCRIPTION
Bring back usb_cam.

This reverts commit ac52fe1a0242c11b9b4f7668f001c6596f03573a.

@LeonChambers as far as I can tell, a lot of the plumbing for still images and video is in place, but the usb_cam package is missing. Is that correct?

Also, what is the best way to manage these dependencies do you think? I think we should vendor them, since ROS does not seem to have a package manager. But that would require us moving the openag_brain package down a level and managing the workspace via version control instead.

Thoughts?